### PR TITLE
Print package name, ignore `oddjob` config files

### DIFF
--- a/tumbleweed_white_list.yml
+++ b/tumbleweed_white_list.yml
@@ -1106,3 +1106,10 @@
   defined_by:
     - gnome-settings-daemon
   yast_support:
+
+- files:
+    - /etc/oddjobd.conf.d/*
+  defined_by:
+    - oddjob
+    - oddjob-mkhomedir
+  yast_support:


### PR DESCRIPTION
- Whitelisted the `oddjob` packages
- Print also the package name for each found file
  - Replace a simple file list with a "file => package" `Hash`