### PR TITLE
Update whitelist

### DIFF
--- a/tumbleweed_white_list.yml
+++ b/tumbleweed_white_list.yml
@@ -1113,3 +1113,11 @@
     - oddjob
     - oddjob-mkhomedir
   yast_support:
+
+# Support implemented in https://github.com/yast/yast-pam/pull/20
+- files:
+    - /usr/etc/nsswitch.conf
+  defined_by:
+    - glibc
+  yast_support:
+    - yast2-pam

--- a/tumbleweed_white_list.yml
+++ b/tumbleweed_white_list.yml
@@ -221,6 +221,13 @@
     - chrony
   yast_support:
   
+# Planned as https://trello.com/c/R27sCT8E/4031-chrony-is-moving-config-to-d-space
+- files:
+    - /etc/chrony.d/*
+  defined_by:
+    - chrony-pool-suse
+  yast_support:
+
 - files:
     - /etc/dnf*
   defined_by:
@@ -1121,3 +1128,49 @@
     - glibc
   yast_support:
     - yast2-pam
+
+- files:
+    - /usr/etc/default/container-*
+  defined_by:
+    - containers-systemd
+  yast_support:
+
+- files:
+    - /usr/etc/cmrt.conf
+  defined_by:
+    - libcmrt1
+  yast_support:
+
+- files:
+    - /etc/obs/services/*
+  defined_by:
+    - obs-service-obs_scm-common
+  yast_support:
+
+- files:
+    - /etc/sway/config.d/*
+  defined_by:
+    - sway-branding-openSUSE
+  yast_support:
+
+- files:
+    - /etc/xrootd/client.plugins.d/*
+  defined_by:
+    - xrootd-client-libs
+  yast_support:
+
+- files:
+    - /usr/etc/X11
+    - /usr/etc/X11/xsm
+    - /usr/etc/X11/xsm/*
+  defined_by:
+    - xsm
+  yast_support:
+
+# YaST uses zypper and there is no plan to support yum in the short term
+# (and YaST would not mangle directly with the repo files anyway)
+- files:
+    - /etc/yum.repos.d/*
+  defined_by:
+    - rpm-repos-openSUSE-Tumbleweed
+  yast_support:


### PR DESCRIPTION
Add `/usr/etc/nsswitch.conf` since it's already supported (see https://trello.com/c/uDtev8AO/1949-5-add-support-for-usr-etc-nsswitchconf).

Opportunity taken to mark some other files that are clearly irrelevant for YaST.

After merging this, only the following files should stay in the output:

```
/etc/issue.d/cockpit.issue (package: cockpit-ws)
/etc/motd.d/cockpit (package: cockpit-ws)
/usr/etc/pam.d/vnc (package: xorg-x11-Xvnc)
```

I left the issue and motd ones because I'm not sure if YaST takes them into consideration somehow (I found some references to motd in yast2-security and found that we have a `PrintMotd` AutoYaST key).

And I left the vnc one because I'm not sure whether is relevant for VNC installation/configuration or for yast2-auth-client