### PR TITLE
Add spamass-milter configuration file to whitelist

### DIFF
--- a/tumbleweed_white_list.yml
+++ b/tumbleweed_white_list.yml
@@ -1286,3 +1286,8 @@
     - spack
   yast_support:
 
+- files:
+    - /usr/etc/default/spamass-milter
+  defined_by:
+    - spamass-milter
+  yast_support:


### PR DESCRIPTION
Related to the latest check output

```
Downloading https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml...
Downloading https://download.opensuse.org/tumbleweed/repo/oss/repodata/e4cd43a9660959db717d92d0866ee6e16dcd380c3c8f9c425fdfc9ea46c0df5c-filelists.xml.gz...
.............................................................
Processed 61981 packages

Found 1 new files/directories, please check them:

/usr/etc/default/spamass-milter (package: spamass-milter)
```

---

https://linux.die.net/man/1/spamass-milter