### PR TITLE
Update whitelist

### DIFF
--- a/tumbleweed_white_list.yml
+++ b/tumbleweed_white_list.yml
@@ -1440,3 +1440,19 @@
     - audit
     - audit-audispd-plugins
   yast_support:
+
+# Planned as https://trello.com/c/Ocom0NlD/4812-new-usr-etc-ssh-files
+- files:
+    - /usr/etc/ssh/ssh_config
+    - /usr/etc/ssh
+    - /usr/etc/ssh/moduli
+    - /usr/etc/ssh/sshd_config
+  defined_by:
+    - openssh-clients
+    - openssh-server
+    - openssh-common
+  yast_support:
+    - yast2-samba-client
+    - yast2-firstboot
+    - yast2-installation
+    - yast2-yast2

--- a/tumbleweed_white_list.yml
+++ b/tumbleweed_white_list.yml
@@ -1430,3 +1430,13 @@
   defined_by:
     - lightdm-deepin-greeter
   yast_support:
+
+- files:
+    - /etc/audit/plugins.d/af_unix.conf
+    - /etc/audit/plugins.d/syslog.conf
+    - /etc/audit/plugins.d/au-remote.conf
+    - /etc/audit/plugins.d/audispd-zos-remote.conf
+  defined_by:
+    - audit
+    - audit-audispd-plugins
+  yast_support:


### PR DESCRIPTION
New files have appeared since [last time (Apr 29, 2021)](https://github.com/yast/usr-etc-test/pull/9) we updated the white list.

This pull request adds them to the list, including some entries that have produced the following card:

* https://trello.com/c/Ocom0NlD/4812-new-usr-etc-ssh-files (internal link)

---

Result of [file check](https://github.com/yast/usr-etc-test/pull/10/checks?check_run_id=3090625365#step:4:9)

```
Run ./check_tumbleweed
Downloading https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml...
Downloading https://download.opensuse.org/tumbleweed/repo/oss/repodata/b16811202f2dcbc424d12725f8516f695a235d0f629f4d6d575a5b7d8fa34f3c-filelists.xml.gz...
...................................................................
Processed 67087 packages

OK, nothing new found
```