### PR TITLE
Update whitelist for /usr/etc/security

### DIFF
--- a/tumbleweed_white_list.yml
+++ b/tumbleweed_white_list.yml
@@ -1514,3 +1514,15 @@
     - jupyter-jupyter_core-filesystem
     - jupyter-notebook-filesystem
   yast_support:
+
+# Planned with https://trello.com/c/z7hNodYR/5000-add-support-for-usr-etc-sercurity
+- files:
+    - /usr/etc/security
+    - /usr/etc/security/limits.conf
+  defined_by:
+    - pam
+  yast_support:
+    - yast-pam
+    - yast-samba-client
+    - yast-packager
+    - yast-update


### PR DESCRIPTION
Adding new files related to changes in [Pluggable Authentication Modules for Linux project](https://github.com/linux-pam/linux-pam), aka [Linux-PAM](http://www.linux-pam.org/whatispam.html).

Planned as https://trello.com/c/z7hNodYR (internal link)