### PR TITLE
Update whitelist for /usr/etc/keylime.conf

### DIFF
--- a/tumbleweed_white_list.yml
+++ b/tumbleweed_white_list.yml
@@ -1526,3 +1526,10 @@
     - yast-samba-client
     - yast-packager
     - yast-update
+
+- files:
+    - /usr/etc/keylime.conf
+  defined_by:
+    - keylime-config
+  yast_support:
+    - skelcd-control-MicroOS


### PR DESCRIPTION
The system has detected the [Keylime](https://keylime.dev/) _keylime.conf_ file in /usr.

An issue has been open at https://github.com/yast/skelcd-control-MicroOS/issues/49