### PR TITLE
Update known list with latest findings (2022-04-18)

### DIFF
--- a/tumbleweed_known_changes.yml
+++ b/tumbleweed_known_changes.yml
@@ -1606,3 +1606,16 @@
   defined_by:
     - gnome-software
   yast_support:
+
+- files:
+    - /etc/daxctl.conf.d/daxctl.example.conf
+    - /etc/ndctl.conf.d/*
+  defined_by:
+    - ndctl
+  yast_support:
+
+- files:
+    - /etc/zypp/vendors.d/00-openSUSE.conf
+  defined_by:
+    - openSUSE-release
+  yast_support:


### PR DESCRIPTION


The checker has reported new files in _/etc_, but none of them affect the YaST modules. 

Check the changes in the known list to see them. 