### PR TITLE
Update the known list (2022-05-05)

### DIFF
--- a/tumbleweed_known_changes.yml
+++ b/tumbleweed_known_changes.yml
@@ -1444,9 +1444,11 @@
 # Planned as https://trello.com/c/Ocom0NlD/4812-new-usr-etc-ssh-files
 - files:
     - /usr/etc/ssh/ssh_config
+    - /usr/etc/ssh/ssh_config.d
     - /usr/etc/ssh
     - /usr/etc/ssh/moduli
     - /usr/etc/ssh/sshd_config
+    - /usr/etc/ssh/sshd_config.d
   defined_by:
     - openssh-clients
     - openssh-server

--- a/tumbleweed_known_changes.yml
+++ b/tumbleweed_known_changes.yml
@@ -1619,3 +1619,10 @@
   defined_by:
     - openSUSE-release
   yast_support:
+
+- files:
+    - /usr/etc/xdg/foot
+    - /usr/etc/xdg/foot/*
+  defined_by:
+    - foot
+  yast_support:

--- a/tumbleweed_known_changes.yml
+++ b/tumbleweed_known_changes.yml
@@ -1449,10 +1449,12 @@
     - /usr/etc/ssh/moduli
     - /usr/etc/ssh/sshd_config
     - /usr/etc/ssh/sshd_config.d
+    - /usr/etc/ssh/sshd_config.d/50-permit-root-login.conf
   defined_by:
     - openssh-clients
     - openssh-server
     - openssh-common
+    - openssh-server-config-rootlogin
   yast_support:
     - yast2-samba-client
     - yast2-firstboot


### PR DESCRIPTION
For adding new findings.

 * `/usr/etc/xdg/foot` files from [foot - A fast, lightweight and minimalistic Wayland terminal emulator](https://codeberg.org/dnkl/foot)
 * `/usr/etc/ssh/ssh[d]_config.d` directories from `openssh-common` and `openssh-server` packages
 * `/usr/etc/ssh/sshd_config.d/50-permit-root-login.conf` from `openssh-server-config-rootlogin` package
    
    See lines 194-203, 339, and 469-470 of https://build.opensuse.org/package/view_file/openSUSE:Factory/openssh/openssh.spec?expand=1

   194-203

    ```spec
    %package server-config-rootlogin
    Summary:        Config to permit root logins to sshd
    Group:          Productivity/Networking/SSH
    Requires:       %{name}-server = %{version}-%{release}
   
    %description server-config-rootlogin
    The openssh-server package by default disallows password based
    root logins. This package provides a config that does. It's useful
    to temporarily have a password based login to be able to use
    ssh-copy-id(1).
    ```
 
    339

    ```spec
    echo "PermitRootLogin yes" > %{buildroot}%{_distconfdir}/ssh/sshd_config.d/50-permit-root-login.conf
    ```

    469-470
   
    ```spec
    %files server-config-rootlogin
    %{_distconfdir}/ssh/sshd_config.d/50-permit-root-login.conf
    ```

---

Added a comment in the related Trello card, https://trello.com/c/Ocom0NlD/#comment-6273aa4c0c060d64971d9dc2 (internal link)