### PR TITLE
Update known files for guestfs-tools

### DIFF
--- a/tumbleweed_known_changes.yml
+++ b/tumbleweed_known_changes.yml
@@ -907,6 +907,7 @@
 
 - files:
     - /etc/xdg/virt-builder/repos.d*
+    - /etc/virt-builder/repos.d*
   defined_by:
     - guestfs-tools
   yast_support:


### PR DESCRIPTION
Adding all files under _/etc/virt-builder/repos.d_ directory.

Related to https://github.com/yast/usr-etc-test/runs/6749740877?check_suite_focus=true